### PR TITLE
Prevent layout shifts on mobile editor previews

### DIFF
--- a/vermar/src/pages/[u]/[id]/edit.tsx
+++ b/vermar/src/pages/[u]/[id]/edit.tsx
@@ -97,8 +97,8 @@ const Edit = () => {
               </>
             ) : (
               <>
-                <h1 className="w-full break-all">{title || "Untitled"}</h1>
-                <div className="mb-2">
+                <h1 className="w-full break-all mb-4">{title || "Untitled"}</h1>
+                <div className="min-h-[385px]">
                   <Markdown source={source} />
                 </div>
               </>

--- a/vermar/src/pages/new.tsx
+++ b/vermar/src/pages/new.tsx
@@ -61,8 +61,8 @@ const New = () => {
               </>
             ) : (
               <>
-                <h1 className="w-full break-all">{title || "Untitled"}</h1>
-                <div className="mb-2">
+                <h1 className="w-full break-all mb-4">{title || "Untitled"}</h1>
+                <div className="min-h-[385px]">
                   <Markdown source={source} />
                 </div>
               </>


### PR DESCRIPTION
- set minimum height for preview content to disable layout shifts.

ref: #56 